### PR TITLE
feat: add Odoo XML-RPC connector and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv/
+.env
+__pycache__/

--- a/src/odoo_connector.py
+++ b/src/odoo_connector.py
@@ -1,0 +1,25 @@
+import os
+from dotenv import load_dotenv
+import xmlrpc.client
+
+load_dotenv()
+
+ODOO_URL = os.getenv("ODOO_URL")
+ODOO_DB = os.getenv("ODOO_DB")
+ODOO_USERNAME = os.getenv("ODOO_USERNAME")
+ODOO_PASSWORD = os.getenv("ODOO_PASSWORD_OR_API_KEY")
+
+def get_odoo_connection():
+    """Establish and return an authenticated connection to the Odoo ERP instance."""
+    try:
+        common = xmlrpc.client.ServerProxy(f"{ODOO_URL}/xmlrpc/2/common")
+        uid = common.authenticate(ODOO_DB, ODOO_USERNAME, ODOO_PASSWORD, {})
+        models = xmlrpc.client.ServerProxy(f"{ODOO_URL}/xmlrpc/2/object")
+        if uid:
+            return uid, models
+        else:
+            print("❌ Failed to authenticate with Odoo.")
+            return None, None
+    except Exception as e:
+        print("❌ Connection error:", e)
+        return None, None

--- a/test_connection.py
+++ b/test_connection.py
@@ -1,0 +1,10 @@
+from src.odoo_connector import get_odoo_connection
+
+uid, models = get_odoo_connection()
+
+if uid and models:
+    print(f"✅ Connected to Odoo! UID = {uid}")
+    version = models.execute_kw('odoodb', uid, 'admin', 'res.partner', 'search_read', [[]], {'limit': 1})
+    print("Sample query result:", version)
+else:
+    print("❌ Connection to Odoo failed.")


### PR DESCRIPTION
This PR adds the initial connection layer to the local Odoo ERP instance via XML-RPC.

✔️ Implements `get_odoo_connection()` using environment variables  
✔️ Verifies connection via test script (`test_connection.py`)  
✔️ Uses .env file for credentials and adds it to .gitignore

Tested locally with Docker-based Odoo 17 instance on port 8069.
